### PR TITLE
fix(api): changed userIdKey in all authenticated route

### DIFF
--- a/api/internal/handlers/offers_create.go
+++ b/api/internal/handlers/offers_create.go
@@ -35,7 +35,7 @@ func (a *API) handlerOffersCreate(w http.ResponseWriter, r *http.Request) {
 		Offer   Offer `json:"offer"`
 	}
 
-	userID, ok := r.Context().Value("userID").(uuid.UUID)
+	userID, ok := r.Context().Value(userIDKey).(uuid.UUID)
 	if !ok {
 		respond.WithError(w, http.StatusUnauthorized, "Couldn't get userID from context", nil)
 		return

--- a/api/internal/handlers/raw_educations_create.go
+++ b/api/internal/handlers/raw_educations_create.go
@@ -39,7 +39,7 @@ func (a *API) handlerRawEducationsCreate(w http.ResponseWriter, r *http.Request)
 		Education Education
 	}
 
-	userID, ok := r.Context().Value("userID").(uuid.UUID)
+	userID, ok := r.Context().Value(userIDKey).(uuid.UUID)
 	if !ok {
 		respond.WithError(w, http.StatusInternalServerError, "Could not get userID, from Context", nil)
 		return

--- a/api/internal/handlers/raw_experiences_create.go
+++ b/api/internal/handlers/raw_experiences_create.go
@@ -42,7 +42,7 @@ func (a *API) handlerRawExperiencesCreate(w http.ResponseWriter, r *http.Request
 		Experience Experience
 	}
 
-	userID, ok := r.Context().Value("userID").(uuid.UUID)
+	userID, ok := r.Context().Value(userIDKey).(uuid.UUID)
 	if !ok {
 		respond.WithError(w, http.StatusInternalServerError, "Could not get userID, from Context", nil)
 		return

--- a/api/internal/handlers/raw_hobbies_create.go
+++ b/api/internal/handlers/raw_hobbies_create.go
@@ -30,7 +30,7 @@ func (a *API) handlerRawHobbiesCreate(w http.ResponseWriter, r *http.Request) {
 		Hobby   Hobby
 	}
 
-	userID, ok := r.Context().Value("userID").(uuid.UUID)
+	userID, ok := r.Context().Value(userIDKey).(uuid.UUID)
 	if !ok {
 		respond.WithError(w, http.StatusInternalServerError, "Could not get userID, from Context", nil)
 		return

--- a/api/internal/handlers/raw_projects_create.go
+++ b/api/internal/handlers/raw_projects_create.go
@@ -40,7 +40,7 @@ func (a *API) handlerRawProjectsCreate(w http.ResponseWriter, r *http.Request) {
 		Project Project
 	}
 
-	userID, ok := r.Context().Value("userID").(uuid.UUID)
+	userID, ok := r.Context().Value(userIDKey).(uuid.UUID)
 	if !ok {
 		respond.WithError(w, http.StatusInternalServerError, "Could not get userID, from Context", nil)
 		return

--- a/api/internal/handlers/raw_stacks_create.go
+++ b/api/internal/handlers/raw_stacks_create.go
@@ -30,7 +30,7 @@ func (a *API) handlerRawStacksCreate(w http.ResponseWriter, r *http.Request) {
 		Stack   Stack
 	}
 
-	userID, ok := r.Context().Value("userID").(uuid.UUID)
+	userID, ok := r.Context().Value(userIDKey).(uuid.UUID)
 	if !ok {
 		respond.WithError(w, http.StatusInternalServerError, "Could not get userID, from Context", nil)
 		return


### PR DESCRIPTION
Authenticated route didnt work because context was expecting a string "userID" instzead of the variable userIdKey of type userIdKeyType
